### PR TITLE
Remove cssify as a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,16 +24,6 @@
     "develop": "done-serve --static --develop --port 8080"
   },
   "main": "can-view-model",
-  "browser": {
-    "transform": [
-      "cssify"
-    ]
-  },
-  "browserify": {
-    "transform": [
-      "cssify"
-    ]
-  },
   "keywords": [
     "canjs",
     "donejs"
@@ -59,7 +49,6 @@
   "devDependencies": {
     "can-define": "^0.6.0",
     "can-map": "^3.0.0-pre.3",
-    "cssify": "^0.6.0",
     "bit-docs": "0.0.7",
     "done-serve": "^0.2.0",
     "donejs-cli": "^0.8.0",


### PR DESCRIPTION
This removes cssify as a dependency since it is not used in this project
and breaks Browserify.