### PR TITLE
Landscaper: Remove deprecated can-util methods and replace with can-globals

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ node_modules
 
 doc/
 dist/
+package-lock.json

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/can-view-model.js
+++ b/can-view-model.js
@@ -3,7 +3,7 @@ var domData = require("can-util/dom/data/data");
 var SimpleMap = require("can-simple-map");
 var types = require("can-types");
 var ns = require("can-namespace");
-var getDocument = require("can-util/dom/document/document");
+var getDocument = require("can-globals/document/document");
 var isArrayLike = require("can-util/js/is-array-like/is-array-like");
 var canReflect = require("can-reflect");
 

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "donejs"
   ],
   "dependencies": {
+    "can-globals": "^0.2.3",
     "can-namespace": "1.0.0",
     "can-reflect": "^1.2.1",
     "can-simple-map": "^3.3.0",


### PR DESCRIPTION
This pull request was created with [Landscaper](https://github.com/bitovi/landscaper).
The following code mods were used to create this PR:

1. **https://gist.github.com/imaustink/d1faff15b89df8fb7964c5d5c3945e72**

Please review this PR carefully as Landscaper does not guarantee any code mod's quality.